### PR TITLE
This Adds a schema parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +627,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -727,11 +766,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -758,6 +843,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -1138,6 +1229,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,6 +1552,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,6 +1855,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,6 +1976,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piston-float"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad78bf43dcf80e8f950c92b84f938a0fc7590b7f6866fbcbeca781609c115590"
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +2007,34 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1996,6 +2157,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quaternion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f228fdb4cf3d4f76c98dc318b73f23df2bd7cbed8319e9ee28696aaf4737c0b3"
+dependencies = [
+ "vecmath",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,6 +2217,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
 dependencies = [
  "bitflags 2.4.2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2258,6 +2448,12 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
+dependencies = [
+ "criterion",
+ "nom",
+ "quaternion",
+ "thiserror",
+]
 
 [[package]]
 name = "schemars"
@@ -2632,7 +2828,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
 dependencies = [
- "itertools",
+ "itertools 0.12.1",
  "nom",
  "unicode_categories",
 ]
@@ -2972,18 +3168,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3029,6 +3225,16 @@ checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3386,6 +3592,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vecmath"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ae1e0d85bca567dee1dcf87fb1ca2e792792f66f87dced8381f99cd91156a"
+dependencies = [
+ "piston-float",
+]
 
 [[package]]
 name = "version_check"

--- a/src/schema/Cargo.toml
+++ b/src/schema/Cargo.toml
@@ -3,6 +3,18 @@ name = "schema"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bench]]
+name = "schema_parser_benchmark"
+harness = false
+
+[[bin]]
+name = "schema_parser"
+path = "src/bin/schema_parser.rs"
 
 [dependencies]
+nom = "7.1.3"
+thiserror = "1.0.58"
+
+[dev-dependencies]
+criterion = { version = "0.5.1", features = ["html_reports"] }
+quaternion = "1.0.0"

--- a/src/schema/README.md
+++ b/src/schema/README.md
@@ -6,33 +6,33 @@ it can parse the schema and generate the following:
 
 ```rust
 Schema {
-            definitions: vec![
-                Definition {
-                    name: "user",
-                    relations: vec![],
-                    permissions: vec![],
-                },
-                Definition {
-                    name: "resource",
-                    relations: vec![Relation {
-                        name: "manager",
-                        subject: vec![
-                            Associations::Single("user"),
-                            Associations::SubjectSet(SubjectSet {
-                                group: "usergroup",
-                                role: "member",
-                            }),
-                            Associations::SubjectSet(SubjectSet {
-                                group: "usergroup",
-                                role: "manager",
-                            }),
-                        ],
-                    }],
-                    permissions: vec![Permission {
-                        name: "view",
-                        permissions: vec![Permissions::Single("viewer"), Permissions::Single("manager")],
-                    }],
-                },
-            ],
-        }
-        ```
+    definitions: vec![
+        Definition {
+            name: "user",
+            relations: vec![],
+            permissions: vec![],
+        },
+        Definition {
+            name: "resource",
+            relations: vec![Relation {
+                name: "manager",
+                subject: vec![
+                    Associations::Single("user"),
+                    Associations::SubjectSet(SubjectSet {
+                        group: "usergroup",
+                        role: "member",
+                    }),
+                    Associations::SubjectSet(SubjectSet {
+                        group: "usergroup",
+                        role: "manager",
+                    }),
+                ],
+            }],
+            permissions: vec![Permission {
+                name: "view",
+                permissions: vec![Permissions::Single("viewer"), Permissions::Single("manager")],
+            }],
+        },
+    ],
+}
+```

--- a/src/schema/README.md
+++ b/src/schema/README.md
@@ -1,0 +1,38 @@
+# Schema
+
+This is using a schema similar to [SpiceDB Schema](https://authzed.com/docs/spicedb/concepts/schema).
+
+it can parse the schema and generate the following:
+
+```rust
+Schema {
+            definitions: vec![
+                Definition {
+                    name: "user",
+                    relations: vec![],
+                    permissions: vec![],
+                },
+                Definition {
+                    name: "resource",
+                    relations: vec![Relation {
+                        name: "manager",
+                        subject: vec![
+                            Associations::Single("user"),
+                            Associations::SubjectSet(SubjectSet {
+                                group: "usergroup",
+                                role: "member",
+                            }),
+                            Associations::SubjectSet(SubjectSet {
+                                group: "usergroup",
+                                role: "manager",
+                            }),
+                        ],
+                    }],
+                    permissions: vec![Permission {
+                        name: "view",
+                        permissions: vec![Permissions::Single("viewer"), Permissions::Single("manager")],
+                    }],
+                },
+            ],
+        }
+        ```

--- a/src/schema/benches/schema_parser_benchmark.rs
+++ b/src/schema/benches/schema_parser_benchmark.rs
@@ -1,0 +1,39 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use schema::parse_schema;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let input = r#"
+    definition user {}
+
+    definition resource {
+        relation manager: user | usergroup#member | usergroup#manager
+        relation viewer: user | usergroup#member | usergroup#manager
+    
+        permission manage = manager
+        permission view = viewer + manager
+    }
+    
+    definition usergroup {
+        relation manager: user | usergroup#member | usergroup#manager
+        relation direct_member: user | usergroup#member | usergroup#manager
+    
+        permission member = direct_member + manager
+    }
+    
+    definition organization {
+        relation group: usergroup
+        relation administrator: user | usergroup#member | usergroup#manager
+        relation direct_member: user
+    
+        relation resource: resource
+    
+        permission admin = administrator
+        permission member = direct_member + administrator + group->member
+    }
+    "#;
+
+    c.bench_function("parse_s", |b| b.iter(|| parse_schema(black_box(&input))));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/schema/src/lib.rs
+++ b/src/schema/src/lib.rs
@@ -1,14 +1,3 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+mod parser;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub use parser::parse_schema;

--- a/src/schema/src/parser/mod.rs
+++ b/src/schema/src/parser/mod.rs
@@ -1,0 +1,11 @@
+mod schema;
+pub use schema::parse_schema;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("Invalid schema provided.")]
+    InvalidSchema,
+    #[error("Parsing error")]
+    ParsingError,
+}

--- a/src/schema/src/parser/schema.rs
+++ b/src/schema/src/parser/schema.rs
@@ -1,0 +1,547 @@
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    character::complete::{alphanumeric1, char, multispace0, multispace1, newline, space0},
+    combinator::{map, recognize},
+    multi::{many0, separated_list0},
+    sequence::{delimited, pair, tuple},
+    IResult,
+};
+
+use super::AppError;
+
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
+#[allow(dead_code)]
+struct SubjectSet<'a> {
+    group: &'a str,
+    role: &'a str,
+}
+
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
+enum Associations<'a> {
+    Single(&'a str),
+    SubjectSet(SubjectSet<'a>),
+}
+
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Relation<'a> {
+    name: &'a str,
+    subject: Vec<Associations<'a>>,
+}
+
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
+#[allow(dead_code)]
+struct PermissionSet<'a> {
+    group: &'a str,
+    permission: &'a str,
+}
+
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
+enum Permissions<'a> {
+    Single(&'a str),
+    PermissionSet(PermissionSet<'a>),
+}
+
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Permission<'a> {
+    name: &'a str,
+    permissions: Vec<Permissions<'a>>,
+}
+
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Definition<'a> {
+    name: &'a str,
+    relations: Vec<Relation<'a>>,
+    permissions: Vec<Permission<'a>>,
+}
+
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct Schema<'a> {
+    definitions: Vec<Definition<'a>>,
+}
+
+fn parse_identifier(input: &str) -> IResult<&str, &str> {
+    recognize(pair(alphanumeric1, many0(pair(char('_'), alphanumeric1))))(input)
+}
+
+// usergroup#member
+fn parse_entities_associations(input: &str) -> IResult<&str, SubjectSet> {
+    let (input, (group, _, role)) = tuple((parse_identifier, tag("#"), parse_identifier))(input)?;
+    Ok((input, SubjectSet { group, role }))
+}
+
+// usergroup#member OR owner
+fn parse_either_entities_associations(input: &str) -> IResult<&str, Associations> {
+    alt((
+        map(parse_entities_associations, |d| Associations::SubjectSet(d)),
+        map(parse_identifier, |d| Associations::Single(d)),
+    ))(input)
+}
+
+// usergroup#member | usergroup#admin | owner
+fn parse_associations(input: &str) -> IResult<&str, Vec<Associations>> {
+    let (input, entities) =
+        separated_list0(delimited(space0, tag("|"), space0), parse_either_entities_associations)(input)?;
+
+    Ok((input, entities))
+}
+
+// relation manager: user | usergroup#member | usergroup#manager
+fn parse_relation(input: &str) -> IResult<&str, Relation> {
+    let (input, (_, _, _, rel_type, _, _, rel_entities)) = tuple((
+        multispace0,
+        tag("relation"),
+        multispace0,
+        parse_identifier,
+        tag(":"),
+        multispace0,
+        parse_associations,
+    ))(input)?;
+
+    Ok((
+        input,
+        Relation {
+            name: rel_type,
+            subject: rel_entities,
+        },
+    ))
+}
+
+// group->member
+fn parse_permission_set(input: &str) -> IResult<&str, PermissionSet> {
+    let (input, (group, _, permission)) = tuple((parse_identifier, tag("->"), parse_identifier))(input)?;
+    Ok((input, PermissionSet { group, permission }))
+}
+
+// administrator OR group->member
+fn parse_either_permission(input: &str) -> IResult<&str, Permissions> {
+    alt((
+        map(parse_permission_set, |ps| Permissions::PermissionSet(ps)),
+        map(parse_identifier, |p| Permissions::Single(p)),
+    ))(input)
+}
+
+// administrator + group->member
+fn parse_multi_permissions(input: &str) -> IResult<&str, Vec<Permissions>> {
+    let (input, permissions) = separated_list0(delimited(space0, tag("+"), space0), parse_either_permission)(input)?;
+
+    Ok((input, permissions))
+}
+
+// permission member = direct_member + manager
+fn parse_permission(input: &str) -> IResult<&str, Permission> {
+    let (input, (_, _, _, permission, _, _, _, permissions)) = tuple((
+        multispace0,
+        tag("permission"),
+        multispace1,
+        parse_identifier,
+        multispace0,
+        tag("="),
+        multispace0,
+        parse_multi_permissions,
+    ))(input)?;
+
+    Ok((
+        input,
+        Permission {
+            name: permission,
+            permissions,
+        },
+    ))
+}
+
+fn parse_all_relations(input: &str) -> IResult<&str, Vec<Relation>> {
+    separated_list0(newline, parse_relation)(input)
+}
+
+fn parse_all_permissions(input: &str) -> IResult<&str, Vec<Permission>> {
+    separated_list0(newline, parse_permission)(input)
+}
+
+fn parse_definition(input: &str) -> IResult<&str, Definition> {
+    let (input, (_, definition, _, relations, _, permissions, _, _, _)) = tuple((
+        tuple((multispace0, tag("definition"), multispace0)),
+        parse_identifier,
+        tuple((multispace0, tag("{"), multispace0)),
+        parse_all_relations,
+        multispace0,
+        parse_all_permissions,
+        multispace0,
+        char('}'),
+        multispace0,
+    ))(input)?;
+
+    Ok((
+        input,
+        Definition {
+            name: definition,
+            relations,
+            permissions,
+        },
+    ))
+}
+fn parse_schema_definitions(input: &str) -> IResult<&str, Schema> {
+    let (input, definitions) = many0(delimited(multispace0, parse_definition, multispace0))(input)?;
+
+    Ok((input, Schema { definitions }))
+}
+
+pub fn parse_schema(input: &str) -> Result<Schema, AppError> {
+    let (_, schema) = parse_schema_definitions(input).map_err(|_| AppError::ParsingError)?;
+
+    if schema.definitions.is_empty() {
+        return Err(AppError::InvalidSchema);
+    }
+    Ok(schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_entities_associations() {
+        let association = SubjectSet {
+            group: "usergroup",
+            role: "member",
+        };
+        let result = dbg!(parse_entities_associations("usergroup#member"));
+
+        let Ok((_, parsed_association)) = result else {
+            panic!();
+        };
+        assert_eq!(association, parsed_association);
+    }
+
+    #[test]
+    fn test_parse_multi_associations() {
+        let association = vec![
+            Associations::SubjectSet(SubjectSet {
+                group: "usergroup",
+                role: "member",
+            }),
+            Associations::SubjectSet(SubjectSet {
+                group: "usergroup",
+                role: "admin",
+            }),
+            Associations::Single("owner"),
+        ];
+        let result = dbg!(parse_associations("usergroup#member | usergroup#admin | owner"));
+
+        let Ok((_, parsed_association)) = result else {
+            panic!();
+        };
+        assert_eq!(association, parsed_association);
+    }
+
+    #[test]
+    fn test_parse_relation() {
+        let role = "       relation manager: user | usergroup#member | usergroup#manager";
+        let relation = Relation {
+            name: "manager",
+            subject: vec![
+                Associations::Single("user"),
+                Associations::SubjectSet(SubjectSet {
+                    group: "usergroup",
+                    role: "member",
+                }),
+                Associations::SubjectSet(SubjectSet {
+                    group: "usergroup",
+                    role: "manager",
+                }),
+            ],
+        };
+        let result = dbg!(parse_relation(dbg!(role)));
+
+        let Ok((_, parsed)) = result else {
+            panic!();
+        };
+        assert_eq!(relation, parsed);
+    }
+
+    #[test]
+    fn test_parse_multi_relation() {
+        let s = "       relation manager: user | usergroup#member | usergroup#manager
+               relation manager: user | usergroup#member | usergroup#manager";
+        let p = vec![
+            Relation {
+                name: "manager",
+                subject: vec![
+                    Associations::Single("user"),
+                    Associations::SubjectSet(SubjectSet {
+                        group: "usergroup",
+                        role: "member",
+                    }),
+                    Associations::SubjectSet(SubjectSet {
+                        group: "usergroup",
+                        role: "manager",
+                    }),
+                ],
+            },
+            Relation {
+                name: "manager",
+                subject: vec![
+                    Associations::Single("user"),
+                    Associations::SubjectSet(SubjectSet {
+                        group: "usergroup",
+                        role: "member",
+                    }),
+                    Associations::SubjectSet(SubjectSet {
+                        group: "usergroup",
+                        role: "manager",
+                    }),
+                ],
+            },
+        ];
+        let result = dbg!(parse_all_relations(dbg!(s)));
+
+        let Ok((_, parsed)) = result else {
+            panic!();
+        };
+        assert_eq!(p, parsed);
+    }
+
+    #[test]
+    fn test_parse_permission_set() {
+        let permission_set = PermissionSet {
+            group: "group",
+            permission: "member",
+        };
+        let result = dbg!(parse_permission_set("group->member"));
+
+        let Ok((_, parsed)) = result else {
+            panic!();
+        };
+        assert_eq!(permission_set, parsed);
+    }
+
+    #[test]
+    fn test_parse_multi_permissions() {
+        let multi_permissions = vec![
+            Permissions::Single("direct_member"),
+            Permissions::Single("manager"),
+            Permissions::PermissionSet(PermissionSet {
+                group: "group",
+                permission: "member",
+            }),
+        ];
+        let result = dbg!(parse_multi_permissions("direct_member + manager + group->member"));
+
+        let Ok((_, parsed)) = result else {
+            panic!();
+        };
+        assert_eq!(multi_permissions, parsed);
+    }
+
+    #[test]
+    fn test_parse_permission() {
+        let permission = Permission {
+            name: "member",
+            permissions: vec![
+                Permissions::Single("direct_member"),
+                Permissions::Single("administrator"),
+                Permissions::PermissionSet(PermissionSet {
+                    group: "group",
+                    permission: "member",
+                }),
+            ],
+        };
+        let result = dbg!(parse_permission(
+            "     permission member = direct_member + administrator + group->member"
+        ));
+
+        let Ok((_, parsed)) = result else {
+            panic!();
+        };
+        assert_eq!(permission, parsed);
+    }
+
+    #[test]
+    fn test_parse_multi_permission() {
+        let permission_str = "     permission member = direct_member + administrator + group->member
+        permission member = direct_member + administrator + group->member";
+        let pers = vec![
+            Permission {
+                name: "member",
+                permissions: vec![
+                    Permissions::Single("direct_member"),
+                    Permissions::Single("administrator"),
+                    Permissions::PermissionSet(PermissionSet {
+                        group: "group",
+                        permission: "member",
+                    }),
+                ],
+            },
+            Permission {
+                name: "member",
+                permissions: vec![
+                    Permissions::Single("direct_member"),
+                    Permissions::Single("administrator"),
+                    Permissions::PermissionSet(PermissionSet {
+                        group: "group",
+                        permission: "member",
+                    }),
+                ],
+            },
+        ];
+        let result = dbg!(parse_all_permissions(dbg!(permission_str)));
+
+        let Ok((_, parsed)) = result else {
+            panic!();
+        };
+        assert_eq!(pers, parsed);
+    }
+
+    #[test]
+    fn test_parse_empty_definition() {
+        let definition_str = "definition user {}";
+        let definition = Definition {
+            name: "user",
+            relations: vec![],
+            permissions: vec![],
+        };
+        let result = dbg!(parse_definition(dbg!(definition_str)));
+
+        let Ok((_, parsed)) = result else {
+            panic!();
+        };
+        assert_eq!(definition, parsed);
+    }
+
+    #[test]
+    fn test_parse_definition() {
+        let definition_str = "
+        definition resource {
+                    relation manager: user | usergroup#member | usergroup#manager
+                    relation viewer: user | usergroup#member | usergroup#manager
+
+                    permission manage = manager
+                    permission view = viewer + manager
+                }";
+        let definition = Definition {
+            name: "resource",
+            relations: vec![
+                Relation {
+                    name: "manager",
+                    subject: vec![
+                        Associations::Single("user"),
+                        Associations::SubjectSet(SubjectSet {
+                            group: "usergroup",
+                            role: "member",
+                        }),
+                        Associations::SubjectSet(SubjectSet {
+                            group: "usergroup",
+                            role: "manager",
+                        }),
+                    ],
+                },
+                Relation {
+                    name: "viewer",
+                    subject: vec![
+                        Associations::Single("user"),
+                        Associations::SubjectSet(SubjectSet {
+                            group: "usergroup",
+                            role: "member",
+                        }),
+                        Associations::SubjectSet(SubjectSet {
+                            group: "usergroup",
+                            role: "manager",
+                        }),
+                    ],
+                },
+            ],
+            permissions: vec![
+                Permission {
+                    name: "manage",
+                    permissions: vec![Permissions::Single("manager")],
+                },
+                Permission {
+                    name: "view",
+                    permissions: vec![Permissions::Single("viewer"), Permissions::Single("manager")],
+                },
+            ],
+        };
+        let result = dbg!(parse_definition(dbg!(definition_str)));
+
+        let Ok((_, parsed)) = result else {
+            panic!();
+        };
+        assert_eq!(definition, parsed);
+    }
+
+    #[test]
+    fn test_parse_schema() {
+        let s = "
+        definition user {}
+
+        definition resource {
+            relation manager: user | usergroup#member | usergroup#manager
+            permission view = viewer + manager
+        }";
+        let p = Schema {
+            definitions: vec![
+                Definition {
+                    name: "user",
+                    relations: vec![],
+                    permissions: vec![],
+                },
+                Definition {
+                    name: "resource",
+                    relations: vec![Relation {
+                        name: "manager",
+                        subject: vec![
+                            Associations::Single("user"),
+                            Associations::SubjectSet(SubjectSet {
+                                group: "usergroup",
+                                role: "member",
+                            }),
+                            Associations::SubjectSet(SubjectSet {
+                                group: "usergroup",
+                                role: "manager",
+                            }),
+                        ],
+                    }],
+                    permissions: vec![Permission {
+                        name: "view",
+                        permissions: vec![Permissions::Single("viewer"), Permissions::Single("manager")],
+                    }],
+                },
+            ],
+        };
+        let result = dbg!(parse_schema(dbg!(s)));
+
+        let Ok(parsed) = result else {
+            panic!();
+        };
+        assert_eq!(p, parsed);
+    }
+
+    #[test]
+    fn test_parse_invalid_schema() {
+        let s = r#"
+        schema {
+            query: Query
+        }
+        
+        type Query {
+            hello: String
+        }
+        "#;
+
+        let result = dbg!(parse_schema(dbg!(s)));
+
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
This code snippet utilizes a schema inspired by the [SpiceDB Schema](https://authzed.com/docs/spicedb/concepts/schema), demonstrating how to parse such a schema and generate the corresponding Rust data structures:

```rust
Schema {
    definitions: vec![
        Definition {
            name: "user",
            relations: vec![],
            permissions: vec![],
        },
        Definition {
            name: "resource",
            relations: vec![Relation {
                name: "manager",
                subject: vec![
                    Associations::Single("user"),
                    Associations::SubjectSet(SubjectSet {
                        group: "usergroup",
                        role: "member",
                    }),
                    Associations::SubjectSet(SubjectSet {
                        group: "usergroup",
                        role: "manager",
                    }),
                ],
            }],
            permissions: vec![Permission {
                name: "view",
                permissions: vec![Permissions::Single("viewer"), Permissions::Single("manager")],
            }],
        },
    ],
}
```